### PR TITLE
Add WebRTC call center example

### DIFF
--- a/webrtc/callcenter/README.md
+++ b/webrtc/callcenter/README.md
@@ -1,0 +1,23 @@
+# Simple WebRTC Call Center
+
+This example demonstrates a minimal WebRTC call center using a WebSocket signaling server.
+
+## Server
+
+```
+cd server
+npm install
+npm start
+```
+
+The server listens on `ws://localhost:3000`.
+
+## Client
+
+Open `client/index.html` in a modern browser. You can serve the directory using any static HTTP server.
+
+1. Enter a unique username.
+2. Click another username to initiate a call.
+3. Accept incoming calls when prompted.
+
+Both audio and video are shared between peers.

--- a/webrtc/callcenter/client/index.html
+++ b/webrtc/callcenter/client/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>WebRTC Call Center</title>
+  <style>
+    #users li { cursor: pointer; }
+    video { width: 300px; height: 200px; background: black; }
+  </style>
+  <script type="module" src="script.js" defer></script>
+</head>
+<body>
+  <form id="login-form">
+    <input name="username" placeholder="Username" required />
+    <button type="submit">Join</button>
+  </form>
+  <div id="app" style="display:none;">
+    <h3>Logged in as <span id="me"></span></h3>
+    <ul id="users"></ul>
+    <video id="localVideo" autoplay muted playsinline></video>
+    <video id="remoteVideo" autoplay playsinline></video>
+    <button id="hangup" style="display:none;">Hangup</button>
+  </div>
+</body>
+</html>

--- a/webrtc/callcenter/client/script.js
+++ b/webrtc/callcenter/client/script.js
@@ -1,0 +1,141 @@
+const loginForm = document.getElementById('login-form');
+const usersUl = document.getElementById('users');
+const localVideo = document.getElementById('localVideo');
+const remoteVideo = document.getElementById('remoteVideo');
+const appDiv = document.getElementById('app');
+const meSpan = document.getElementById('me');
+const hangupBtn = document.getElementById('hangup');
+
+let socket;
+let username;
+let peer;
+let localStream;
+let currentTarget;
+
+loginForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  username = new FormData(loginForm).get('username');
+  initSocket();
+});
+
+function initSocket() {
+  socket = new WebSocket('ws://localhost:3000');
+  socket.addEventListener('open', () => {
+    socket.send(JSON.stringify({ type: 'login', payload: { username } }));
+  });
+  socket.addEventListener('message', (event) => {
+    const message = JSON.parse(event.data);
+    handleMessage(message);
+  });
+}
+
+async function handleMessage(message) {
+  switch (message.type) {
+    case 'login':
+      if (message.success) {
+        meSpan.textContent = username;
+        loginForm.style.display = 'none';
+        appDiv.style.display = 'block';
+      } else {
+        alert('Username already used');
+      }
+      break;
+    case 'users':
+      updateUserList(message.payload);
+      break;
+    case 'offer':
+      await handleOffer(message.payload);
+      break;
+    case 'answer':
+      if (peer) await peer.setRemoteDescription(message.payload.answer);
+      break;
+    case 'candidate':
+      if (peer) await peer.addIceCandidate(message.payload.candidate);
+      break;
+    case 'hangup':
+      endCall();
+      break;
+  }
+}
+
+function updateUserList(list) {
+  usersUl.innerHTML = '';
+  list.filter((u) => u !== username).forEach((user) => {
+    const li = document.createElement('li');
+    li.textContent = user;
+    li.addEventListener('click', () => startCall(user));
+    usersUl.appendChild(li);
+  });
+}
+
+async function ensureLocalStream() {
+  if (!localStream) {
+    localStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+    localVideo.srcObject = localStream;
+  }
+}
+
+function createPeer(target) {
+  const pc = new RTCPeerConnection();
+  pc.onicecandidate = (e) => {
+    if (e.candidate) {
+      socket.send(
+        JSON.stringify({ type: 'candidate', payload: { target, candidate: e.candidate } })
+      );
+    }
+  };
+  pc.ontrack = (e) => {
+    remoteVideo.srcObject = e.streams[0];
+  };
+  pc.onconnectionstatechange = () => {
+    if (pc.connectionState === 'disconnected' || pc.connectionState === 'closed') {
+      endCall();
+    }
+  };
+  return pc;
+}
+
+async function startCall(target) {
+  await ensureLocalStream();
+  peer = createPeer(target);
+  currentTarget = target;
+  localStream.getTracks().forEach((t) => peer.addTrack(t, localStream));
+  const offer = await peer.createOffer();
+  await peer.setLocalDescription(offer);
+  socket.send(JSON.stringify({ type: 'offer', payload: { target, offer } }));
+  hangupBtn.style.display = 'block';
+}
+
+async function handleOffer(payload) {
+  const accept = confirm(`${payload.from} is calling you. Accept?`);
+  if (!accept) {
+    socket.send(JSON.stringify({ type: 'hangup', payload: { target: payload.from } }));
+    return;
+  }
+  await ensureLocalStream();
+  currentTarget = payload.from;
+  peer = createPeer(payload.from);
+  localStream.getTracks().forEach((t) => peer.addTrack(t, localStream));
+  await peer.setRemoteDescription(payload.offer);
+  const answer = await peer.createAnswer();
+  await peer.setLocalDescription(answer);
+  socket.send(
+    JSON.stringify({ type: 'answer', payload: { target: payload.from, answer } })
+  );
+  hangupBtn.style.display = 'block';
+}
+
+function endCall() {
+  if (peer) {
+    peer.close();
+    peer = null;
+  }
+  remoteVideo.srcObject = null;
+  hangupBtn.style.display = 'none';
+  if (currentTarget) {
+    socket.send(JSON.stringify({ type: 'hangup', payload: { target: currentTarget } }));
+    currentTarget = null;
+  }
+}
+
+hangupBtn.addEventListener('click', endCall);

--- a/webrtc/callcenter/server/index.js
+++ b/webrtc/callcenter/server/index.js
@@ -1,0 +1,67 @@
+const { createServer } = require('http');
+const { WebSocketServer } = require('ws');
+
+const server = createServer();
+const wss = new WebSocketServer({ server });
+
+const clients = new Map(); // username -> connection
+
+function broadcastUsers() {
+  const users = Array.from(clients.keys());
+  const message = JSON.stringify({ type: 'users', payload: users });
+  for (const [, ws] of clients) {
+    ws.send(message);
+  }
+}
+
+wss.on('connection', (ws) => {
+  ws.on('message', (data) => {
+    let msg;
+    try {
+      msg = JSON.parse(data);
+    } catch {
+      return;
+    }
+    switch (msg.type) {
+      case 'login': {
+        const username = msg.payload.username;
+        if (clients.has(username)) {
+          ws.send(JSON.stringify({ type: 'login', success: false }));
+          return;
+        }
+        ws.username = username;
+        clients.set(username, ws);
+        ws.send(
+          JSON.stringify({ type: 'login', success: true, username })
+        );
+        broadcastUsers();
+        break;
+      }
+      case 'offer':
+      case 'answer':
+      case 'candidate':
+      case 'hangup': {
+        const target = msg.payload.target;
+        const targetWs = clients.get(target);
+        if (targetWs) {
+          targetWs.send(
+            JSON.stringify({
+              type: msg.type,
+              payload: { ...msg.payload, from: ws.username },
+            })
+          );
+        }
+        break;
+      }
+    }
+  });
+
+  ws.on('close', () => {
+    if (ws.username) {
+      clients.delete(ws.username);
+      broadcastUsers();
+    }
+  });
+});
+
+server.listen(3000, () => console.log('Signaling server on port 3000'));

--- a/webrtc/callcenter/server/package.json
+++ b/webrtc/callcenter/server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "webrtc-callcenter-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "ws": "^8.18.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple WebSocket signaling server
- provide minimal client to perform audio/video calls
- document how to run the example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e3f5fa1f8832192eca65369e60c69